### PR TITLE
emlator 周りの設定を修正

### DIFF
--- a/frontend/firebase.json
+++ b/frontend/firebase.json
@@ -28,14 +28,8 @@
     "rules": "firestore.rules"
   },
   "emulators": {
-    "functions": {
-      "port": 5001
-    },
     "firestore": {
       "port": 8080
-    },
-    "hosting": {
-      "port": 5000
     },
     "ui": {
       "enabled": true

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "emulator": "npm run build && firebase emulators:start --import ./.data --export-on-exit ./.data --only functions,auth,hosting,firestore",
+    "emulator": "firebase emulators:start --project demo-emulator --import .data --export-on-exit --only auth,firestore",
     "deploy": "firebase deploy --only functions,hosting,firestore",
     "logs": "firebase functions:log",
     "lint": "yarn lint:eslint; yarn lint:prettier",

--- a/frontend/src/infra/firebase.ts
+++ b/frontend/src/infra/firebase.ts
@@ -6,18 +6,43 @@ import {
   getFirestore,
 } from "firebase/firestore/lite";
 
-const app = initializeApp({
-  projectId: 'emulator',
-  appId: 'test',
-  apiKey: 'test',
-});
-const db = getFirestore(app);
-const auth = getAuth(app);
+const initializeFirebase = () => {
+  const app = initializeApp({
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    databaseURL: process.env.NEXT_PUBLIC_FIREBASE_DATABASE_URL,
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+    measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
+  });
+  const db = getFirestore(app);
+  const auth = getAuth(app);
+  return { db, auth };
+};
 
-if (process.env.NEXT_PUBLIC_EMULATOR === "true") {
+const initializeEmulatorFirebase = () => {
+  const app = initializeApp({
+    projectId: "demo-emulator",
+    authDomain: "xxx",
+    databaseURL: "xxx",
+    appId: "test",
+    apiKey: "test",
+    storageBucket: "xxx",
+    messagingSenderId: "xxx",
+    measurementId: "xxx",
+  });
+  const db = getFirestore(app);
+  const auth = getAuth(app);
   connectAuthEmulator(auth, "http://localhost:9099");
   connectFirestoreEmulator(db, "localhost", 8080);
-}
+  return { db, auth };
+};
+
+const { db, auth } = process.env.NEXT_PUBLIC_EMULATOR
+  ? initializeEmulatorFirebase()
+  : initializeFirebase();
 
 export const login = async () => {
   const provider = new GoogleAuthProvider();


### PR DESCRIPTION
# WHY

どっかのタイミングでデグレして壊れていた

# WHAT

- functions, hosting は emulator 上で使わないので削除 (next dev でみたほうが env などの都合上便利)
	- それに伴って emulator 起動時の build も必要ないので削除
- emulator 時の firebase の initializeApp 周りなどを修正
	- project 名は `demo-` 始まりじゃないとだめ？らしい(https://firebase.google.com/docs/emulator-suite/connect_auth?hl=ja#choose_a_firebase_project)
	- `authDomain` とかもなんでも良いので何らか文字列を指定しないとエラーになるので埋めている

