### PR TITLE
prod でも emulator になっている

### DIFF
--- a/frontend/src/infra/firebase.ts
+++ b/frontend/src/infra/firebase.ts
@@ -40,9 +40,10 @@ const initializeEmulatorFirebase = () => {
   return { db, auth };
 };
 
-const { db, auth } = process.env.NEXT_PUBLIC_EMULATOR
-  ? initializeEmulatorFirebase()
-  : initializeFirebase();
+const { db, auth } =
+  process.env.NEXT_PUBLIC_EMULATOR === "true"
+    ? initializeEmulatorFirebase()
+    : initializeFirebase();
 
 export const login = async () => {
   const provider = new GoogleAuthProvider();


### PR DESCRIPTION
NEXT_PUBLIC で注入した環境変数は全て文字列になるので
`process.env.NEXT_PUBLIC_EMULATOR === "true"` にする 

