### PR TITLE
クエリ用のページを作成

### DIFF
--- a/frontend/src/components/pages/PokemonQuery/index.tsx
+++ b/frontend/src/components/pages/PokemonQuery/index.tsx
@@ -1,0 +1,60 @@
+import { FC, useEffect } from "react";
+import React from "react";
+
+import {
+  Box,
+  Button,
+  Heading,
+  Text,
+  VStack,
+  useClipboard,
+} from "@chakra-ui/react";
+
+import { usePokemonIdsQuery } from "@/features/pokemonQuery/usecase/usePokemonIdsQuery";
+import { useAllPokemonsGet } from "@/features/pokemons";
+import { useUser } from "@/features/users";
+
+export const PokemonQuery: FC = () => {
+  const { user } = useUser();
+  const { queryPokemonIds } = usePokemonIdsQuery(user?.uid, "lucky");
+  const { allPokemons } = useAllPokemonsGet();
+
+  const {
+    onCopy,
+    value: query,
+    setValue: setQuery,
+    hasCopied,
+  } = useClipboard("");
+
+  useEffect(() => {
+    if (queryPokemonIds && allPokemons) {
+      const dexNos = queryPokemonIds.flatMap((pokemonId) => {
+        return allPokemons.get(pokemonId)?.dexNo ?? [];
+      });
+      return setQuery(dexNos.join(","));
+    } else {
+      return setQuery("");
+    }
+  }, [queryPokemonIds, allPokemons, setQuery]);
+
+  return (
+    <VStack w="100%" h="100%" px="10px">
+      <Heading as="h2" size="md" p={1} alignSelf={"start"}>
+        <Text as="u" color={"blue.500"}>
+          条件
+        </Text>
+      </Heading>
+      <Heading as="h2" size="md" p={1} alignSelf={"start"}>
+        <Text as="u" color={"blue.500"}>
+          検索文字列
+        </Text>
+      </Heading>
+      <Box w="90%" h="50px" overflow={"auto"}>
+        <Text overflowWrap="anywhere">{query}</Text>
+      </Box>
+      <Button w="90%" h="60px" onClick={onCopy} whiteSpace="unset">
+        {hasCopied ? "Copied!" : "Copy"}
+      </Button>
+    </VStack>
+  );
+};

--- a/frontend/src/components/pages/PokemonQuery/index.tsx
+++ b/frontend/src/components/pages/PokemonQuery/index.tsx
@@ -1,23 +1,36 @@
-import { FC, useEffect } from "react";
-import React from "react";
+import React, { FC, useEffect, useState } from "react";
 
+import { CheckIcon, MinusIcon } from "@chakra-ui/icons";
 import {
   Box,
   Button,
+  HStack,
   Heading,
   Text,
   VStack,
   useClipboard,
 } from "@chakra-ui/react";
 
+import { ToggleIconButtonWithText } from "@/components/uiParts/ToggleButton";
 import { usePokemonIdsQuery } from "@/features/pokemonQuery/usecase/usePokemonIdsQuery";
 import { useAllPokemonsGet } from "@/features/pokemons";
 import { useUser } from "@/features/users";
+
+interface SearchQuery {
+  excludeSpecial: boolean;
+  excludeShiny: boolean;
+  excludeLucky: boolean;
+}
 
 export const PokemonQuery: FC = () => {
   const { user } = useUser();
   const { queryPokemonIds } = usePokemonIdsQuery(user?.uid, "lucky");
   const { allPokemons } = useAllPokemonsGet();
+  const [searchQuery, setSearchQuery] = useState<SearchQuery>({
+    excludeSpecial: true,
+    excludeShiny: true,
+    excludeLucky: true,
+  });
 
   const {
     onCopy,
@@ -31,11 +44,20 @@ export const PokemonQuery: FC = () => {
       const dexNos = queryPokemonIds.flatMap((pokemonId) => {
         return allPokemons.get(pokemonId)?.dexNo ?? [];
       });
-      return setQuery(dexNos.join(","));
-    } else {
-      return setQuery("");
+      dexNos.sort((a, b) => a - b);
+      let q = "(" + dexNos.join(",") + ")";
+      if (searchQuery.excludeSpecial) {
+        q = "!とくべつ&" + q;
+      }
+      if (searchQuery.excludeShiny) {
+        q = "!色違い&" + q;
+      }
+      if (searchQuery.excludeLucky) {
+        q = "!キラ&" + q;
+      }
+      setQuery(q);
     }
-  }, [queryPokemonIds, allPokemons, setQuery]);
+  }, [queryPokemonIds, allPokemons, setQuery, searchQuery]);
 
   return (
     <VStack w="100%" h="100%" px="10px">
@@ -44,17 +66,67 @@ export const PokemonQuery: FC = () => {
           条件
         </Text>
       </Heading>
+      <>
+        <Heading as="h3" size="sm" p={1} alignSelf={"start"}>
+          図鑑状況
+        </Heading>
+        <Box>キラ図鑑が埋まっている</Box>
+        <Heading as="h3" size="sm" p={1} alignSelf={"start"}>
+          除外
+        </Heading>
+        <HStack>
+          <ToggleIconButtonWithText
+            toggle={() =>
+              setSearchQuery((old) => ({
+                ...old,
+                excludeLucky: !old.excludeLucky,
+              }))
+            }
+            isClicked={searchQuery.excludeLucky}
+            text="キラ"
+            onIcon={<CheckIcon />}
+            offIcon={<MinusIcon />}
+            props={{ rounded: "10" }}
+          />
+          <ToggleIconButtonWithText
+            toggle={() =>
+              setSearchQuery((old) => ({
+                ...old,
+                excludeShiny: !old.excludeShiny,
+              }))
+            }
+            isClicked={searchQuery.excludeShiny}
+            text="色違い"
+            onIcon={<CheckIcon />}
+            offIcon={<MinusIcon />}
+            props={{ rounded: "10" }}
+          />
+          <ToggleIconButtonWithText
+            toggle={() =>
+              setSearchQuery((old) => ({
+                ...old,
+                excludeSpecial: !old.excludeSpecial,
+              }))
+            }
+            isClicked={searchQuery.excludeSpecial}
+            text="特別"
+            onIcon={<CheckIcon />}
+            offIcon={<MinusIcon />}
+            props={{ rounded: "10" }}
+          />
+        </HStack>
+      </>
       <Heading as="h2" size="md" p={1} alignSelf={"start"}>
         <Text as="u" color={"blue.500"}>
           検索文字列
         </Text>
       </Heading>
-      <Box w="90%" h="50px" overflow={"auto"}>
+      <Button w="90%" h="60px" onClick={onCopy} whiteSpace="unset">
+        {hasCopied ? "Copied!" : "Copy to Clipboard"}
+      </Button>
+      <Box w="90%" flex={1} overflow={"auto"}>
         <Text overflowWrap="anywhere">{query}</Text>
       </Box>
-      <Button w="90%" h="60px" onClick={onCopy} whiteSpace="unset">
-        {hasCopied ? "Copied!" : "Copy"}
-      </Button>
     </VStack>
   );
 };

--- a/frontend/src/components/projects/MenuBar.tsx
+++ b/frontend/src/components/projects/MenuBar.tsx
@@ -17,6 +17,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { BiUserCircle } from "react-icons/bi";
+import { MdOutlineManageSearch } from "react-icons/md";
 
 import { useLogout, useUser } from "@/features/users";
 
@@ -104,6 +105,14 @@ export const MenuBar: FC = (props) => {
         disabled={!user}
       >
         <Image boxSize="23px" src="/menu_icons/rocket.png" alt="rocket" />
+      </SimpleMenuButton>
+
+      <SimpleMenuButton
+        onClick={() => router.push(`/query`)}
+        isSelected={router.asPath.startsWith(`/query`)}
+        disabled={!user}
+      >
+        <MdOutlineManageSearch size="23" />
       </SimpleMenuButton>
       <Spacer />
 

--- a/frontend/src/components/uiParts/Select.tsx
+++ b/frontend/src/components/uiParts/Select.tsx
@@ -20,7 +20,7 @@ export const Select = <T,>(props: SelectProps<T>) => {
   }, []);
 
   const getLabel_ = (v?: T) => {
-    if (v) {
+    if (v !== undefined) {
       if (getLabel) {
         return getLabel(v);
       } else {
@@ -36,7 +36,7 @@ export const Select = <T,>(props: SelectProps<T>) => {
       <ChakraReactSelect
         value={{ value: value, label: getLabel_(value) }}
         onChange={(v) => {
-          if (onChange && v && v.value) {
+          if (onChange && v && v.value !== undefined) {
             onChange(v.value);
           }
         }}

--- a/frontend/src/features/pokemonQuery/usecase/usePokemonIdsQuery.ts
+++ b/frontend/src/features/pokemonQuery/usecase/usePokemonIdsQuery.ts
@@ -1,0 +1,29 @@
+import { useQuery } from "@tanstack/react-query";
+
+import "firebase/compat/auth";
+import "firebase/compat/firestore";
+import { PokedexType } from "@/features/userPokedex";
+import { queryPokemonIds } from "@/infra/users";
+
+export const usePokemonIdsQuery = (
+  userId?: string,
+  pokedexType?: PokedexType
+) => {
+  const { isLoading, isError, data, error } = useQuery({
+    queryKey: ["usePokemonIdsQuery", userId, pokedexType],
+    queryFn: () => {
+      if (userId && pokedexType) {
+        return queryPokemonIds(userId, pokedexType);
+      }
+    },
+    staleTime: Infinity,
+    cacheTime: Infinity,
+    enabled: !!userId && !!pokedexType,
+  });
+  return {
+    queryPokemonIds: data,
+    useQueryPokemonIdsLoading: isLoading,
+    isError: isError,
+    error: error,
+  };
+};

--- a/frontend/src/features/pokemonQuery/usecase/usePokemonIdsQuery.ts
+++ b/frontend/src/features/pokemonQuery/usecase/usePokemonIdsQuery.ts
@@ -6,19 +6,20 @@ import { PokedexType } from "@/features/userPokedex";
 import { queryPokemonIds } from "@/infra/users";
 
 export const usePokemonIdsQuery = (
-  userId?: string,
-  pokedexType?: PokedexType
+  pokedexType: PokedexType,
+  pokedexTypeCondition: boolean,
+  userId?: string
 ) => {
   const { isLoading, isError, data, error } = useQuery({
-    queryKey: ["usePokemonIdsQuery", userId, pokedexType],
+    queryKey: ["usePokemonIdsQuery", userId, pokedexType, pokedexTypeCondition],
     queryFn: () => {
-      if (userId && pokedexType) {
-        return queryPokemonIds(userId, pokedexType);
+      if (userId) {
+        return queryPokemonIds(userId, pokedexType, pokedexTypeCondition);
       }
     },
     staleTime: Infinity,
     cacheTime: Infinity,
-    enabled: !!userId && !!pokedexType,
+    enabled: !!userId,
   });
   return {
     queryPokemonIds: data,

--- a/frontend/src/features/userPokedex/index.ts
+++ b/frontend/src/features/userPokedex/index.ts
@@ -3,6 +3,7 @@ export {
   defaultUserPokedex,
   newUserPokedex,
   PokedexTypeChoices,
+  GetPokedexTypeLabel,
 } from "@/features/userPokedex/model/pokedex";
 export type {
   UserPokedex,

--- a/frontend/src/features/userPokedex/model/pokedex.ts
+++ b/frontend/src/features/userPokedex/model/pokedex.ts
@@ -24,6 +24,26 @@ export const PokedexTypeChoices: PokedexType[] = [
   "purify",
   "lucky",
 ];
+export const GetPokedexTypeLabel = (pokedexType: PokedexType) => {
+  switch (pokedexType) {
+    case "normal":
+      return "通常";
+    case "star3":
+      return "星3";
+    case "shiny":
+      return "色違い";
+    case "shinyStar3":
+      return "星3色違い";
+    case "max":
+      return "評価MAX";
+    case "shadow":
+      return "シャドウ";
+    case "purify":
+      return "ライト";
+    case "lucky":
+      return "キラ";
+  }
+};
 
 export type UserPokedex = {
   dexNo: number;

--- a/frontend/src/infra/users.ts
+++ b/frontend/src/infra/users.ts
@@ -103,9 +103,12 @@ export const countPokedexProgress = async (
 // Query Pokemon Ids
 export const queryPokemonIds = async (
   userId: string,
-  pokedexType: PokedexType
+  pokedexType: PokedexType,
+  pokedexTypeCondition: boolean
 ): Promise<PokemonId[]> => {
-  const whereQueries = [where("isHaving." + pokedexType, "==", false)];
+  const whereQueries = [
+    where("isHaving." + pokedexType, "==", pokedexTypeCondition),
+  ];
   const q = await getDocs(
     query(userPokedexCollection(userId), ...whereQueries)
   );

--- a/frontend/src/infra/users.ts
+++ b/frontend/src/infra/users.ts
@@ -3,6 +3,7 @@ import {
   doc,
   getCount,
   getDoc,
+  getDocs,
   query,
   setDoc,
   where,
@@ -10,7 +11,7 @@ import {
 
 import "firebase/compat/auth";
 import "firebase/compat/firestore";
-import { Pokemon } from "@/features/pokemons";
+import { Pokemon, PokemonId } from "@/features/pokemons";
 import {
   PokedexType,
   UserPokedex,
@@ -97,4 +98,20 @@ export const countPokedexProgress = async (
     query(userPokedexCollection(userId), ...whereQueries)
   );
   return q.data().count;
+};
+
+// Query Pokemon Ids
+export const queryPokemonIds = async (
+  userId: string,
+  pokedexType: PokedexType
+): Promise<PokemonId[]> => {
+  const whereQueries = [where("isHaving." + pokedexType, "==", false)];
+  const q = await getDocs(
+    query(userPokedexCollection(userId), ...whereQueries)
+  );
+  return await Promise.all(
+    q.docs.map(async (doc) => {
+      return doc.id;
+    })
+  );
 };

--- a/frontend/src/pages/query/index.tsx
+++ b/frontend/src/pages/query/index.tsx
@@ -1,0 +1,7 @@
+import { PokemonQuery } from "@/components/pages/PokemonQuery";
+
+const PokemonQueryContainer = () => {
+  return <PokemonQuery />;
+};
+
+export default PokemonQueryContainer;


### PR DESCRIPTION
# WHY

キラを既に所持していて，整理してもよいポケモンを簡単にリストアップできる仕組みがほしい

# WHAT

- 図鑑状況 + 特定の条件を除外した検索文字列を作成
- clipboard にコピペ

ができるようなページを作成