### PR TITLE
イベントグループの並び順を固定する

### DIFF
--- a/frontend/src/features/events/hooks/useEvent.ts
+++ b/frontend/src/features/events/hooks/useEvent.ts
@@ -44,13 +44,16 @@ export const useEvent = () => {
       }, new Map<string, PogoEvent[]>());
 
       const groupedOptions: { label: string; values: PogoEvent[] }[] = [];
-      grouped.forEach((events, eventType) => {
-        groupedOptions.push({
-          label: eventType,
-          values: events.sort(
-            (a, b) => b.startAt.getTime() - a.startAt.getDate()
-          ),
-        });
+      ["開催中", "開催予定", "過去のイベント"].forEach((eventType) => {
+        const groupedEvents = grouped.get(eventType);
+        if (groupedEvents) {
+          groupedOptions.push({
+            label: eventType,
+            values: groupedEvents.sort(
+              (a, b) => b.startAt.getTime() - a.startAt.getDate()
+            ),
+          });
+        }
       });
       return groupedOptions;
     }


### PR DESCRIPTION
# WHY

resolve: #15

# WHAT

- 開催中→開催予定→開催済み の順番で固定
- (とりあえず gofes 前に直しておきたいので一旦，この辺は雑に処理しているのでちゃんと parameter を型定義に直したい